### PR TITLE
litevfs: do not regiter LiteVFS as default VFS

### DIFF
--- a/npm/litevfs/lib/index.js
+++ b/npm/litevfs/lib/index.js
@@ -78,7 +78,7 @@ function getLoadablePath() {
 
 function Database(filename, options) {
   const extdb = sqlite(":memory:");
-  extdb.loadExtension(getLoadablePath());
+  extdb.loadExtension(getLoadablePath(), "sqlite3_litevfs_init_default_vfs");
   extdb.close();
 
   return new sqlite(filename, options);


### PR DESCRIPTION
Default extension entrypoint will now register LiteVFS but not make
it the default VFS.

An additional entry point is still provided for better-sqlite3 that
lacks URI parsing in the default build.
