### PR TITLE
litevfs: don't immediately fetch existing pages after write

### DIFF
--- a/crates/litevfs/src/database.rs
+++ b/crates/litevfs/src/database.rs
@@ -425,6 +425,7 @@ impl Database {
         };
 
         self.pos = Some(pos);
+        self.syncer.set_pos(&self.name, self.pos);
 
         Ok(())
     }


### PR DESCRIPTION
Inform the syncer about our new positions once LiteVFS successfuly ships
an LTX file to LFSC, so that we don't have to re-fetch the pages
we already have.
