### PR TITLE
ci: switch from actions-rs/toolchain to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "stable"
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
 
       - name: cargo fmt
@@ -35,9 +35,9 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "stable"
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
 
       - name: Run unit tests
@@ -79,10 +79,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "stable"
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
+          components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
 
@@ -114,15 +114,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "stable"
+          targets: wasm32-unknown-emscripten
+          components: clippy, rustfmt
       - uses: mymindstorm/setup-emsdk@v12
         with:
           version: ${{ env.EM_VERSION }}
           actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
-      - name: Install wasm32-unknown-emscripten target
-        run: rustup target add wasm32-unknown-emscripten
       - name: Install WABT
         run: sudo apt-get install -y wabt
       - uses: Swatinem/rust-cache@v2
@@ -152,9 +151,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "stable"
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,31 +51,24 @@ jobs:
           - os: "ubuntu-latest"
             target: "x86_64-unknown-linux-gnu"
             soname: "liblitevfs.so"
-            cross: true
           - os: "ubuntu-latest"
             target: "x86_64-unknown-linux-musl"
             soname: "liblitevfs.so"
-            cross: true
           - os: "ubuntu-latest"
             target: "aarch64-unknown-linux-gnu"
             soname: "liblitevfs.so"
-            cross: true
           - os: "ubuntu-latest"
             target: "aarch64-unknown-linux-musl"
             soname: "liblitevfs.so"
-            cross: true
           - os: "macos-latest"
             target: "x86_64-apple-darwin"
             soname: "liblitevfs.dylib"
-            cross: false
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
             soname: "liblitevfs.dylib"
-            cross: false
           - os: "windows-latest"
             target: "x86_64-pc-windows-msvc"
             soname: "litevfs.dll"
-            cross: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -86,12 +79,19 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build
-        uses: actions-rs/cargo@v1
+      - name: Install cross
+        if: matrix.os == 'ubuntu-latest'
+        uses: taiki-e/install-action@v2
         with:
-          command: build
-          use-cross: ${{ matrix.cross }}
-          args: --package litevfs --release --target ${{ matrix.target }}
+          tool: cross  
+
+      - name: Build (cross)
+        if: matrix.os == 'ubuntu-latest'
+        run: cross build --package litevfs --release --target ${{ matrix.target }}
+
+      - name: Build
+        if: matrix.os != 'ubuntu-latest'
+        run: cargo build --package litevfs --release --target ${{ matrix.target }}
 
       - name: Package
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -78,6 +78,8 @@ jobs:
           components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
 
       - name: Install cross
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
actions-rs/toolchain hasn't been maintained for more than 3 years
and produces a lot of warnings during CI.

Switch cto dtolnay/rust-toolchain which is actively maintained.
