### PR TITLE
Page prefetching

### DIFF
--- a/crates/litevfs/src/database.rs
+++ b/crates/litevfs/src/database.rs
@@ -4,7 +4,7 @@ use crate::{
     locks::{ConnLock, VfsLock},
     pager::{PageRef, PageSource, Pager},
     syncer::{Changes, Syncer},
-    PageNumLogger, PosLogger,
+    IterLogger, PosLogger,
 };
 use litetx as ltx;
 use sqlite_vfs::OpenAccess;
@@ -545,7 +545,7 @@ impl Database {
                     self.name,
                     PosLogger(&self.pos),
                     PosLogger(&pos),
-                    PageNumLogger(&pgnos)
+                    IterLogger(&pgnos)
                 );
                 for pgno in &pgnos {
                     if let Err(err) = self.pager.del_page(&self.name, *pgno) {

--- a/crates/litevfs/src/database.rs
+++ b/crates/litevfs/src/database.rs
@@ -18,6 +18,9 @@ use std::{
     time,
 };
 
+const DEFAULT_MAX_PREFETCH_PAGES: usize = 32;
+pub(crate) const MAX_MAX_PREFETCH_PAGES: usize = 128;
+
 pub(crate) struct DatabaseManager {
     pager: Arc<Pager>,
     databases: HashMap<String, Arc<RwLock<Database>>>,
@@ -189,7 +192,7 @@ impl Database {
             pos,
             dirty_pages: BTreeMap::new(),
             prefetch_pages: Mutex::new(BTreeSet::new()),
-            prefetch_limit: 32,
+            prefetch_limit: DEFAULT_MAX_PREFETCH_PAGES,
             sync_period: time::Duration::from_secs(1),
             wal,
         })

--- a/crates/litevfs/src/lfsc.rs
+++ b/crates/litevfs/src/lfsc.rs
@@ -1,4 +1,4 @@
-use crate::{http, PosLogger};
+use crate::{http, IterLogger, PosLogger};
 use litetx as ltx;
 use std::{collections::HashMap, env, fmt, io, sync};
 
@@ -273,17 +273,17 @@ impl Client {
         Ok(())
     }
 
-    pub(crate) fn get_page(
+    pub(crate) fn get_pages(
         &self,
         db: &str,
         pos: ltx::Pos,
-        pgno: ltx::PageNum,
+        pgnos: &[ltx::PageNum],
     ) -> Result<Vec<Page>> {
         log::debug!(
-            "[lfsc] get_page: db = {}, pos = {}, pgno = {}",
+            "[lfsc] get_pages: db = {}, pos = {}, pgnos = {}",
             db,
             pos,
-            pgno
+            IterLogger(pgnos)
         );
 
         #[derive(serde::Deserialize)]
@@ -296,7 +296,7 @@ impl Client {
         u.query_pairs_mut()
             .append_pair("db", db)
             .append_pair("pos", &pos.to_string())
-            .append_pair("pgno", &pgno.to_string());
+            .extend_pairs(pgnos.iter().map(|pgno| ("pgno", pgno.to_string())));
 
         Ok(self.call::<GetPageResponse>("GET", u)?.pages)
     }

--- a/crates/litevfs/src/lfsc.rs
+++ b/crates/litevfs/src/lfsc.rs
@@ -327,7 +327,7 @@ impl Client {
 
     #[allow(dead_code)]
     pub(crate) fn acquire_lease(&self, db: &str, op: LeaseOp) -> Result<Lease> {
-        log::debug!("[lfscs] acquire_lease: db = {}, op = {}", db, op);
+        log::debug!("[lfsc] acquire_lease: db = {}, op = {}", db, op);
 
         let mut u = self.host.clone();
         u.set_path("/lease");
@@ -348,7 +348,7 @@ impl Client {
 
     #[allow(dead_code)]
     pub(crate) fn release_lease(&self, db: &str, lease: Lease) -> Result<()> {
-        log::debug!("[lfscs] release_lease: db = {}, lease = {}", db, lease.id);
+        log::debug!("[lfsc] release_lease: db = {}, lease = {}", db, lease.id);
 
         let mut u = self.host.clone();
         u.set_path("/lease");
@@ -369,7 +369,7 @@ impl Client {
         &self,
         positions: &HashMap<String, Option<ltx::Pos>>,
     ) -> Result<HashMap<String, Changes>> {
-        log::debug!("[lfscs] sync: positions = {:?}", positions);
+        log::debug!("[lfsc] sync: positions = {:?}", positions);
 
         let mut u = self.host.clone();
         u.set_path("/sync");

--- a/crates/litevfs/src/lfsc.rs
+++ b/crates/litevfs/src/lfsc.rs
@@ -296,7 +296,14 @@ impl Client {
         u.query_pairs_mut()
             .append_pair("db", db)
             .append_pair("pos", &pos.to_string())
-            .extend_pairs(pgnos.iter().map(|pgno| ("pgno", pgno.to_string())));
+            .append_pair(
+                "pgno",
+                &pgnos
+                    .iter()
+                    .map(|pgno| pgno.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
 
         Ok(self.call::<GetPageResponse>("GET", u)?.pages)
     }

--- a/crates/litevfs/src/lib.rs
+++ b/crates/litevfs/src/lib.rs
@@ -5,6 +5,7 @@ mod leaser;
 mod lfsc;
 mod locks;
 mod pager;
+mod sqlite;
 mod syncer;
 mod vfs;
 

--- a/crates/litevfs/src/lib.rs
+++ b/crates/litevfs/src/lib.rs
@@ -10,7 +10,7 @@ mod vfs;
 
 use litetx as ltx;
 use sqlite_vfs::ffi;
-use std::{collections::BTreeSet, fmt};
+use std::fmt;
 
 /// A custom SQLite error code to indicate that LFSC no longer have the
 /// required state and LiteVFS can't recover from this in the middle of
@@ -30,12 +30,16 @@ impl<'a> fmt::Display for PosLogger<'a> {
     }
 }
 
-struct PageNumLogger<'a>(&'a BTreeSet<ltx::PageNum>);
+struct IterLogger<T>(T);
 
-impl<'a> fmt::Display for PageNumLogger<'a> {
+impl<T, I> fmt::Display for IterLogger<T>
+where
+    T: IntoIterator<Item = I> + Copy,
+    I: fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "[")?;
-        for (i, pgno) in self.0.iter().enumerate() {
+        for (i, pgno) in self.0.into_iter().enumerate() {
             if i > 0 {
                 write!(f, ", ")?;
             }

--- a/crates/litevfs/src/pager.rs
+++ b/crates/litevfs/src/pager.rs
@@ -325,7 +325,7 @@ impl Pager {
             return Err(io::ErrorKind::NotFound.into());
         };
 
-        let pages = match self.client.get_page(db, pos, pgno) {
+        let pages = match self.client.get_pages(db, pos, &[pgno]) {
             Ok(pages) => pages,
             Err(lfsc::Error::PosMismatch(x)) => {
                 log::warn!("get_page_remote: db = {}, pgno = {}, pos mismatch error, requested = {}, got = {}",

--- a/crates/litevfs/src/sqlite.rs
+++ b/crates/litevfs/src/sqlite.rs
@@ -1,0 +1,129 @@
+use std::collections::BTreeSet;
+
+use litetx as ltx;
+
+pub(crate) const HEADER_SIZE: u64 = 100;
+pub(crate) const WRITE_VERSION_OFFSET: usize = 18;
+pub(crate) const READ_VERSION_OFFSET: usize = 19;
+
+pub(crate) fn prefetch_candidates(
+    data: &[u8],
+    pgno: ltx::PageNum,
+) -> Option<BTreeSet<ltx::PageNum>> {
+    let bh = if pgno == ltx::PageNum::ONE {
+        &data[HEADER_SIZE as usize..]
+    } else {
+        data
+    };
+
+    let num_cells = u16::from_be_bytes(bh[3..5].try_into().unwrap());
+    match bh[0] {
+        0x0d if pgno == ltx::PageNum::ONE => Some(master_table(&bh[8..], data, num_cells)),
+        0x02 | 0x05 => {
+            let rightmost_pointer = u32::from_be_bytes(bh[8..12].try_into().unwrap());
+            let mut pgnos = interior_table_or_index(&bh[12..], data, num_cells);
+            if let Ok(pgno) = ltx::PageNum::new(rightmost_pointer) {
+                pgnos.insert(pgno);
+            }
+
+            Some(pgnos)
+        }
+        _ => None,
+    }
+}
+
+// Returns the page numbers of the roots of all tables/indices/etc.
+fn master_table(pointers: &[u8], data: &[u8], num_cells: u16) -> BTreeSet<ltx::PageNum> {
+    pointers[..num_cells as usize * 2]
+        .chunks_exact(2)
+        .map(|c| u16::from_be_bytes(c.try_into().unwrap()) as usize)
+        .filter_map(|cell| {
+            if cell >= data.len() {
+                return None;
+            }
+            let cell = &data[cell..];
+            let (length, cell) = read_varint(cell);
+            let (_rowid, cell) = read_varint(cell);
+
+            // Has overflow page, ignore for now.
+            if length as usize > data.len() - 35 {
+                return None;
+            }
+
+            let (hsize, mut header) = read_varint(cell);
+            let body = &cell[hsize as usize..];
+
+            // skip type/name/tbl_name
+            let mut pgno_offset: usize = 0;
+            for _ in 0..3 {
+                let (typ, header2) = read_varint(header);
+                pgno_offset += type_size(typ);
+
+                header = header2;
+            }
+
+            let (pgno, _) = read_varint(&body[pgno_offset..]);
+
+            ltx::PageNum::new(pgno as u32).ok()
+        })
+        .collect()
+}
+
+// Returns the page numbers of the pages referenced by an interior table or index page.
+fn interior_table_or_index(pointers: &[u8], data: &[u8], num_cells: u16) -> BTreeSet<ltx::PageNum> {
+    pointers[..num_cells as usize * 2]
+        .chunks_exact(2)
+        .map(|c| u16::from_be_bytes(c.try_into().unwrap()) as usize)
+        .filter_map(|cell| {
+            if cell >= data.len() {
+                return None;
+            }
+            let cell = &data[cell..];
+
+            let pgno = u32::from_be_bytes(cell[0..4].try_into().unwrap());
+            ltx::PageNum::new(pgno).ok()
+        })
+        .collect()
+}
+
+fn read_varint(data: &[u8]) -> (i64, &[u8]) {
+    let mut n: i64 = 0;
+    for (i, &b) in data.iter().enumerate() {
+        if i == 8 {
+            n = (n << 8) | (b as i64);
+            return (n, &data[i + 1..]);
+        }
+
+        n = (n << 7) | ((b as i64) & 0x7f);
+        if b < 0x80 {
+            return (n, &data[i + 1..]);
+        }
+    }
+
+    unreachable!();
+}
+
+fn type_size(typ: i64) -> usize {
+    match typ {
+        // NULL, 0 or 1
+        0 | 8 | 9 => 0,
+        // 8-bit int
+        1 => 1,
+        // 16-bit int
+        2 => 2,
+        // 24-bit int
+        3 => 3,
+        // 32-bit int
+        4 => 4,
+        // 48-bit int
+        5 => 6,
+        // 64-bit int
+        6 => 8,
+        // float
+        7 => 8,
+        // internal, should not be present in valid DBs
+        10 | 11 => unreachable!(),
+        n if n % 2 == 0 => ((n - 12) / 2) as usize,
+        n => ((n - 13) / 2) as usize,
+    }
+}

--- a/crates/litevfs/src/vfs.rs
+++ b/crates/litevfs/src/vfs.rs
@@ -22,8 +22,8 @@ use std::{
     thread, time,
 };
 
-const DEFAULT_MAX_PAGES_PER_QUERY: usize = 64;
-const MAX_MAX_PAGES_PER_QUERY: usize = 1024;
+const DEFAULT_MAX_REQS_PER_QUERY: usize = 64;
+const MAX_MAX_REQS_PER_QUERY: usize = 1024;
 
 /// LiteVfs implements SQLite VFS ops.
 pub struct LiteVfs {
@@ -400,7 +400,7 @@ impl LiteDatabaseHandle {
             name,
 
             cur_pages_per_query: 0,
-            max_pages_per_query: DEFAULT_MAX_PAGES_PER_QUERY,
+            max_pages_per_query: DEFAULT_MAX_REQS_PER_QUERY,
         }
     }
 
@@ -594,17 +594,17 @@ impl DatabaseHandle for LiteDatabaseHandle {
                 Err(e) => Some(Err(io::Error::new(io::ErrorKind::InvalidInput, e))),
             },
 
-            ("litevfs_max_pages_per_query", None) => {
+            ("litevfs_max_reqs_per_query", None) => {
                 Some(Ok(Some(self.max_pages_per_query.to_string())))
             }
-            ("litevfs_max_pages_per_query", Some(val)) => match val.parse::<usize>() {
-                Ok(val) if val <= MAX_MAX_PAGES_PER_QUERY => {
+            ("litevfs_max_reqs_per_query", Some(val)) => match val.parse::<usize>() {
+                Ok(val) if val <= MAX_MAX_REQS_PER_QUERY => {
                     self.max_pages_per_query = val;
                     Some(Ok(None))
                 }
                 Ok(_) => Some(Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    format!("can't be greater than {}", MAX_MAX_PAGES_PER_QUERY),
+                    format!("can't be greater than {}", MAX_MAX_REQS_PER_QUERY),
                 ))),
                 Err(e) => Some(Err(io::Error::new(io::ErrorKind::InvalidInput, e))),
             },


### PR DESCRIPTION
The PR implements SQLite page prefetching in order to reduce the number of
network calls LiteVFS does to read a DB.

The following pages are candidates for prefetching:
  - all the pages that we had locally but that have changed on LFSC since the last time we synced;
  - all the pages referenced by SQLite page 1;
  - all the pages referenced by an interior table or index page.

There is only one prefetch list and the actual prefetching happens if and only
if SQLite requests a page that's already in the prefetch list, meaning we guessed
what SQLite wants correctly.