### PR TITLE
litevfs: don't intercept auto_vacuum/incremental_vacuum pragmas

### DIFF
--- a/crates/litevfs/src/vfs.rs
+++ b/crates/litevfs/src/vfs.rs
@@ -576,11 +576,6 @@ impl DatabaseHandle for LiteDatabaseHandle {
                     "WAL is not supported by LiteVFS",
                 )))
             }
-            ("auto_vacuum", _) | ("incremental_vacuum", _) => Some(Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "autovacuum is not supported by LiteVFS",
-            ))),
-
             ("litevfs_min_available_space", None) => Some(Ok(Some(
                 ByteSize::b(self.pager.min_available_space()).to_string_as(true),
             ))),


### PR DESCRIPTION
auto_vacuum DBs can be opene in RO mode only, so the pragmas can't
be applied anyway. Allow them to be queried.
