### PR TITLE
Offline read-only mode

### DIFF
--- a/crates/litevfs/src/database.rs
+++ b/crates/litevfs/src/database.rs
@@ -160,7 +160,6 @@ pub(crate) struct Database {
     dirty_pages: BTreeMap<ltx::PageNum, Option<ltx::Checksum>>,
     prefetch_pages: Mutex<BTreeSet<ltx::PageNum>>,
     pub(crate) prefetch_limit: usize,
-    pub(crate) sync_period: time::Duration,
     wal: bool,
     auto_vacuum: bool,
 }
@@ -217,7 +216,6 @@ impl Database {
             dirty_pages: BTreeMap::new(),
             prefetch_pages: Mutex::new(BTreeSet::new()),
             prefetch_limit: DEFAULT_MAX_PREFETCH_PAGES,
-            sync_period: time::Duration::from_secs(1),
             wal,
             auto_vacuum,
         })
@@ -547,7 +545,7 @@ impl Database {
 
     pub(crate) fn sync(&mut self, force: bool) -> io::Result<()> {
         if force {
-            self.syncer.sync()?;
+            self.syncer.sync_one(&self.name)?;
         }
 
         let pos = match self.syncer.get_changes(&self.name, self.pos)? {

--- a/crates/litevfs/src/lfsc.rs
+++ b/crates/litevfs/src/lfsc.rs
@@ -318,7 +318,6 @@ impl Client {
         self.call("GET", u)
     }
 
-    #[allow(dead_code)]
     pub(crate) fn sync_db(&self, db: &str, pos: Option<ltx::Pos>) -> Result<Changes> {
         log::debug!("[lfsc] sync: db = {}, pos = {}", db, PosLogger(&pos));
 

--- a/crates/litevfs/src/sqlite.rs
+++ b/crates/litevfs/src/sqlite.rs
@@ -1,10 +1,11 @@
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, ops};
 
 use litetx as ltx;
 
 pub(crate) const HEADER_SIZE: u64 = 100;
 pub(crate) const WRITE_VERSION_OFFSET: usize = 18;
 pub(crate) const READ_VERSION_OFFSET: usize = 19;
+pub(crate) const COMMIT_RANGE: ops::Range<usize> = 28..32;
 
 pub(crate) fn prefetch_candidates(
     data: &[u8],

--- a/crates/litevfs/src/vfs.rs
+++ b/crates/litevfs/src/vfs.rs
@@ -485,6 +485,16 @@ impl LiteDatabaseHandle {
 
         Ok(())
     }
+
+    fn cache_db(&mut self) -> io::Result<()> {
+        self.acquire_exclusive()?;
+
+        let ret = self.database.write().unwrap().cache();
+
+        self.release_exclusive();
+
+        ret
+    }
 }
 
 impl Drop for LiteDatabaseHandle {
@@ -664,6 +674,11 @@ impl DatabaseHandle for LiteDatabaseHandle {
                     Err(e) => Some(Err(e)),
                 }
             }
+
+            ("litevfs_cache_db", None) => match self.cache_db() {
+                Ok(()) => Some(Ok(None)),
+                Err(e) => Some(Err(e)),
+            },
             _ => None,
         }
     }

--- a/crates/litevfs/src/vfs.rs
+++ b/crates/litevfs/src/vfs.rs
@@ -614,11 +614,11 @@ impl DatabaseHandle for LiteDatabaseHandle {
             },
 
             ("litevfs_cache_sync_period", None) => Some(Ok(Some(
-                format_duration(self.database.read().unwrap().sync_period).to_string(),
+                format_duration(self.syncer.sync_period(&self.name)).to_string(),
             ))),
             ("litevfs_cache_sync_period", Some(val)) => match parse_duration(val) {
                 Ok(val) => {
-                    self.database.write().unwrap().sync_period = val;
+                    self.syncer.set_sync_period(&self.name, val);
                     Some(Ok(None))
                 }
                 Err(e) => Some(Err(io::Error::new(io::ErrorKind::InvalidInput, e))),


### PR DESCRIPTION
The PR implements support for offline read-only mode.

The following new pragmas are available:
  - `pragma litevfs_cache_sync_period=0` - disables periodic cache sync
  - `pragma litevfs_cache_db` - forces the whole DB to be cached locally
